### PR TITLE
Add basic home page

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,7 +19,8 @@ export default function RootLayout() {
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
+      <Stack initialRouteName="index">
+        <Stack.Screen name="index" options={{ headerShown: false }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,32 @@
+import { Link, Stack } from 'expo-router';
+import { StyleSheet } from 'react-native';
+
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function RootHome() {
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Home' }} />
+      <ThemedView style={styles.container}>
+        <ThemedText type="title">Welcome to Neebys Invoice App</ThemedText>
+        <Link href="/(tabs)" style={styles.link}>
+          <ThemedText type="link">Enter App</ThemedText>
+        </Link>
+      </ThemedView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  link: {
+    marginTop: 15,
+    paddingVertical: 15,
+  },
+});


### PR DESCRIPTION
## Summary
- add a simple home screen at `app/index.tsx`
- update stack navigation to show the new screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3d9a8994832a98b8dd8343ccb642