### PR TITLE
Display Neebys logo in header

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,11 +1,23 @@
 import { Stack } from 'expo-router';
 import { StyleSheet, View, Text } from 'react-native';
+import { Image } from 'expo-image';
 import { Ionicons } from '@expo/vector-icons';
 
 export default function RootHome() {
   return (
     <>
-      <Stack.Screen options={{ title: 'Home' }} />
+      <Stack.Screen
+        options={{
+          title: 'Home',
+          headerLeft: () => (
+            <Image
+              source={require('@/assets/images/neebys.logo.jpg')}
+              style={{ width: 40, height: 40, marginLeft: 10 }}
+              contentFit="contain"
+            />
+          ),
+        }}
+      />
       <View style={styles.container}>
         <Ionicons name="camera" size={64} color="black" />
         <Text style={styles.title}>neebys</Text>


### PR DESCRIPTION
## Summary
- display the `neebys.logo.jpg` image in the Home screen header

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d433e1874832a98eb1fb69dee569a