### PR TITLE
Add navbar and dark theme

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,14 +1,18 @@
 import { Stack } from 'expo-router';
 import { StyleSheet, View, Text } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import NavBar from '@/components/NavBar';
 
 export default function RootHome() {
   return (
     <>
       <Stack.Screen options={{ title: 'Home' }} />
       <View style={styles.container}>
-        <Ionicons name="camera" size={64} color="black" />
-        <Text style={styles.title}>neebys</Text>
+        <NavBar />
+        <View style={styles.content}>
+          <Text style={styles.title}>neebys</Text>
+        </View>
+        <Ionicons name="camera" size={64} color="#ffffff" style={styles.camera} />
       </View>
     </>
   );
@@ -17,13 +21,22 @@ export default function RootHome() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: '#333333',
+  },
+  content: {
+    flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: 'lightblue',
   },
   title: {
     marginTop: 20,
     fontSize: 32,
     fontWeight: 'bold',
+    color: '#ffffff',
+  },
+  camera: {
+    position: 'absolute',
+    bottom: 40,
+    alignSelf: 'center',
   },
 });

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,0 +1,25 @@
+import { Image, StyleSheet, View } from 'react-native';
+
+export default function NavBar() {
+  return (
+    <View style={styles.navbar}>
+      <Image source={require('@/assets/images/neebys.logo.jpg')} style={styles.logo} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  navbar: {
+    height: 60,
+    width: '100%',
+    backgroundColor: '#333333',
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+  },
+  logo: {
+    height: 40,
+    width: 40,
+    resizeMode: 'contain',
+  },
+});

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -8,19 +8,19 @@ const tintColorDark = '#fff';
 
 export const Colors = {
   light: {
-    text: '#11181C',
-    background: '#fff',
+    text: '#ffffff',
+    background: '#333333',
     tint: tintColorLight,
-    icon: '#687076',
-    tabIconDefault: '#687076',
+    icon: '#ffffff',
+    tabIconDefault: '#ffffff',
     tabIconSelected: tintColorLight,
   },
   dark: {
-    text: '#ECEDEE',
-    background: '#151718',
+    text: '#ffffff',
+    background: '#333333',
     tint: tintColorDark,
-    icon: '#9BA1A6',
-    tabIconDefault: '#9BA1A6',
+    icon: '#ffffff',
+    tabIconDefault: '#ffffff',
     tabIconSelected: tintColorDark,
   },
 };


### PR DESCRIPTION
## Summary
- add reusable NavBar with logo
- change theme colors to gray black
- update home screen with NavBar and camera icon at bottom

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d44a4d8b4832aaef294649b8ad71f