### PR TITLE
Fix Babel plugins

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,10 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['nativewind/babel'],
+    plugins: [
+      'nativewind/babel',
+      'expo-router/babel',
+      'react-native-reanimated/plugin',
+    ],
   };
 };


### PR DESCRIPTION
## Summary
- include expo-router and reanimated plugins in the Babel configuration

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d473469f4832ab55087e174e11de4