### PR TITLE
Fix NativeWind babel plugin reference

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,7 +3,7 @@ module.exports = function(api) {
   return {
     presets: ['babel-preset-expo'],
     plugins: [
-      'nativewind/babel',
+      'tailwindcss-react-native/babel',
       'expo-router/babel',
       'react-native-reanimated/plugin',
     ],

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
     "nativewind": "^4.0.1",
+    "tailwindcss-react-native": "^4.5.0",
     "tailwindcss": "^3.4.4",
     "babel-preset-expo": "^9.5.1"
   },


### PR DESCRIPTION
## Summary
- add missing `tailwindcss-react-native` dependency
- update babel config to use the plugin from this package

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d488e9a28832aba147861b6f1bc45