### PR TITLE
Add camera integration and improve nav

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,7 +1,8 @@
 import { Stack } from 'expo-router';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { Image } from 'expo-image';
 import { Ionicons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -9,11 +10,12 @@ import Animated, {
   withSequence,
   withTiming,
 } from 'react-native-reanimated';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import NavBar from '@/components/NavBar';
 
 export default function RootHome() {
   const bounce = useSharedValue(0);
+  const [imageUri, setImageUri] = useState<string | null>(null);
 
   useEffect(() => {
     bounce.value = withRepeat(
@@ -22,6 +24,22 @@ export default function RootHome() {
       true
     );
   }, [bounce]);
+
+  const openCamera = async () => {
+    const permission = await ImagePicker.requestCameraPermissionsAsync();
+    if (!permission.granted) {
+      return;
+    }
+
+    const result = await ImagePicker.launchCameraAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+    });
+
+    if (!result.canceled) {
+      setImageUri(result.assets[0].uri);
+    }
+  };
 
   const cameraStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: bounce.value }],
@@ -47,8 +65,17 @@ export default function RootHome() {
           <Text style={styles.title}>neebys</Text>
         </View>
         <Animated.View style={[styles.cameraWrapper, cameraStyle]}>
-          <Ionicons name="camera" size={64} color="#ffffff" />
+          <Pressable onPress={openCamera}>
+            <Ionicons name="camera" size={64} color="#ffffff" />
+          </Pressable>
         </Animated.View>
+        {imageUri && (
+          <Image
+            source={{ uri: imageUri }}
+            style={styles.preview}
+            contentFit="cover"
+          />
+        )}
       </View>
     </>
   );
@@ -74,5 +101,12 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: 40,
     alignSelf: 'center',
+  },
+  preview: {
+    width: '80%',
+    height: 200,
+    alignSelf: 'center',
+    marginBottom: 20,
+    borderRadius: 8,
   },
 });

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,13 +1,14 @@
-import { Image, View, StyleSheet } from 'react-native';
+import { Image, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function NavBar() {
   return (
-    <View style={styles.container}>
+    <SafeAreaView edges={["top"]} style={styles.container}>
       <Image
         source={require('@/assets/images/neebys.logo.jpg')}
         style={styles.logo}
       />
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.3.2",
+    "expo-image-picker": "~15.5.1",
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.3",
     "expo-splash-screen": "~0.30.10",


### PR DESCRIPTION
## Summary
- keep the nav bar visible on notch devices by using SafeAreaView
- integrate camera access on the home screen
- show photo preview below the button
- add expo-image-picker dependency

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d57b363c0832a87230f6abba5d48a