### PR TITLE
Add gallery picker and tagline

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -41,6 +41,22 @@ export default function RootHome() {
     }
   };
 
+  const openImagePicker = async () => {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+    });
+
+    if (!result.canceled) {
+      setImageUri(result.assets[0].uri);
+    }
+  };
+
   const cameraStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: bounce.value }],
   }));
@@ -50,6 +66,7 @@ export default function RootHome() {
       <Stack.Screen
         options={{
           title: 'Home',
+          headerTitle: 'Scan receipts, create stores.',
           headerLeft: () => (
             <Image
               source={require('@/assets/images/neebys.logo.jpg')}
@@ -65,9 +82,14 @@ export default function RootHome() {
           <Text style={styles.title}>neebys</Text>
         </View>
         <Animated.View style={[styles.cameraWrapper, cameraStyle]}>
-          <Pressable onPress={openCamera}>
-            <Ionicons name="camera" size={64} color="#ffffff" />
-          </Pressable>
+          <View style={styles.iconRow}>
+            <Pressable onPress={openCamera} style={styles.iconButton}>
+              <Ionicons name="camera" size={64} color="#ffffff" />
+            </Pressable>
+            <Pressable onPress={openImagePicker} style={styles.iconButton}>
+              <Ionicons name="image" size={64} color="#ffffff" />
+            </Pressable>
+          </View>
         </Animated.View>
         {imageUri && (
           <Image
@@ -101,6 +123,13 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: 40,
     alignSelf: 'center',
+  },
+  iconRow: {
+    flexDirection: 'row',
+    gap: 16,
+  },
+  iconButton: {
+    paddingHorizontal: 8,
   },
   preview: {
     width: '80%',

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,4 +1,4 @@
-import { Image, StyleSheet } from 'react-native';
+import { Image, StyleSheet, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function NavBar() {
@@ -8,6 +8,7 @@ export default function NavBar() {
         source={require('@/assets/images/neebys.logo.jpg')}
         style={styles.logo}
       />
+      <Text style={styles.tagline}>Scan receipts, create stores.</Text>
     </SafeAreaView>
   );
 }
@@ -25,5 +26,10 @@ const styles = StyleSheet.create({
     height: 40,
     width: 40,
     resizeMode: 'contain',
+  },
+  tagline: {
+    color: '#ffffff',
+    fontSize: 16,
+    marginLeft: 12,
   },
 });

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
-    "start": "expo start",
+    "start": "cross-env EXPO_ROUTER_IMPORT_MODE=sync expo start",
     "reset-project": "node ./scripts/reset-project.js",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
-    "web": "expo start --web",
+    "android": "cross-env EXPO_ROUTER_IMPORT_MODE=sync expo start --android",
+    "ios": "cross-env EXPO_ROUTER_IMPORT_MODE=sync expo start --ios",
+    "web": "cross-env EXPO_ROUTER_IMPORT_MODE=sync expo start --web",
     "lint": "expo lint"
   },
   "dependencies": {
@@ -45,7 +45,8 @@
     "@types/react": "~19.0.10",
     "typescript": "~5.8.3",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0"
+    "eslint-config-expo": "~9.2.0",
+    "cross-env": "^7.0.3"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- add tagline to navigation bar and screen header
- allow selecting an image from the gallery
- fix Expo router import mode via `cross-env`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d59fceba4832a93278beb2c9b0eb5