### PR TITLE
Fix bundling error for private methods

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,7 @@ module.exports = function(api) {
     plugins: [
       'expo-router/babel',
       'react-native-reanimated/plugin',
+      '@babel/plugin-transform-private-methods',
     ],
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,8 @@
         "@types/react": "~19.0.10",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",
-        "typescript": "~5.8.3"
+        "typescript": "~5.8.3",
+        "@babel/plugin-transform-private-methods": "^7.27.1"
       }
     },
     "node_modules/@0no-co/graphql.web": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "typescript": "~5.8.3",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
-    "cross-env": "^7.0.3"
+    "cross-env": "^7.0.3",
+    "@babel/plugin-transform-private-methods": "^7.27.1"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- add `@babel/plugin-transform-private-methods` plugin in Babel config
- declare the plugin as a dev dependency

## Testing
- `npm install --save-dev @babel/plugin-transform-private-methods` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686d5b5a8bb4832aa6661141241ea025