### PR TITLE
Fix Babel loose option

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,7 @@ module.exports = function(api) {
     plugins: [
       'expo-router/babel',
       'react-native-reanimated/plugin',
-      '@babel/plugin-transform-private-methods',
+      ['@babel/plugin-transform-private-methods', { loose: true }],
     ],
   };
 };


### PR DESCRIPTION
## Summary
- align the `@babel/plugin-transform-private-methods` loose option with the rest of the preset to avoid bundling errors

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5cbf4fd4832a86e16396961422ef